### PR TITLE
Make Rocker compilation incremental

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ gradle-rocker-plugin
 [Gradle](http://www.gradle.org) plugin that integrates the Rocker template engine. For each named rocker configuration declared
 in the build, the plugin adds a task to generate the Java sources from the specified Rocker templates and includes the 
 generated Java sources in the matching source set, if existing. The code generation tasks participate in incremental builds and 
-in task output caching by the [Gradle build cache](https://docs.gradle.org/current/userguide/build_cache.html). The plugin can be 
-applied on both Java projects and Android projects.
+in task output caching by the [Gradle build cache](https://docs.gradle.org/current/userguide/build_cache.html). Additionally,
+the compile task itself is incremental, meaning it is optimized so that only templates which have changed are regenerated. 
+The plugin can be applied on both Java projects and Android projects.
 
 You can find out more details about the actual Rocker source code generation in the [Rocker documentation](https://github.com/fizzed).
 

--- a/src/main/java/nu/studer/gradle/rocker/RockerCompile.java
+++ b/src/main/java/nu/studer/gradle/rocker/RockerCompile.java
@@ -12,6 +12,7 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.ParallelizableTask;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
 import org.gradle.process.ExecResult;
 import org.gradle.process.JavaExecSpec;
 
@@ -84,10 +85,15 @@ public class RockerCompile extends DefaultTask {
 
     @SuppressWarnings("unused")
     @TaskAction
-    void doCompile() throws IOException {
-        // delete any generated files from previous runs and any classes compiled by Rocker via hot-reloading
-        getProject().delete(config.getOutputDir());
-        getProject().delete(config.getClassDir());
+    void doCompile(IncrementalTaskInputs incrementalTaskInputs) throws IOException {
+        if (incrementalTaskInputs.isIncremental()) {
+
+        } else {
+            // delete any generated files from previous runs and any classes compiled by Rocker via hot-reloading
+            getProject().delete(config.getOutputDir());
+            getProject().delete(config.getClassDir());
+        }
+
 
         // generate the files from the templates
         ExecResult execResult = executeRocker();

--- a/src/main/java/nu/studer/gradle/rocker/RockerCompile.java
+++ b/src/main/java/nu/studer/gradle/rocker/RockerCompile.java
@@ -4,7 +4,9 @@ import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Task;
 import org.gradle.api.file.ConfigurableFileTree;
+import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.FileTree;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.InputFiles;
@@ -13,6 +15,7 @@ import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.ParallelizableTask;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
+import org.gradle.api.tasks.incremental.InputFileDetails;
 import org.gradle.process.ExecResult;
 import org.gradle.process.JavaExecSpec;
 
@@ -21,6 +24,8 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.Set;
 
 @ParallelizableTask
@@ -86,23 +91,62 @@ public class RockerCompile extends DefaultTask {
     @SuppressWarnings("unused")
     @TaskAction
     void doCompile(IncrementalTaskInputs incrementalTaskInputs) throws IOException {
-        if (incrementalTaskInputs.isIncremental()) {
+        ExecResult execResult;
+        final Set<File> updatedTemplates = new HashSet<>();
 
+        if (incrementalTaskInputs.isIncremental()) {
+            final File tempDir = getTemporaryDir();
+
+            incrementalTaskInputs.outOfDate(new Action<InputFileDetails>() {
+                @Override
+                public void execute(final InputFileDetails inputFileDetails) {
+                    updatedTemplates.add(inputFileDetails.getFile());
+                }
+            });
+
+            // clean any stale files
+            incrementalTaskInputs.removed(new Action<InputFileDetails>() {
+                @Override
+                public void execute(final InputFileDetails inputFileDetails) {
+                    FileTree staleFiles = getProject().fileTree(config.getOutputDir(), new Action<ConfigurableFileTree>() {
+                        @Override
+                        public void execute(ConfigurableFileTree files) {
+                            files.include(getSourceFileName(relativePath(config.getTemplateDir(), inputFileDetails.getFile())));
+                        }
+                    });
+                    getProject().delete(staleFiles);
+                }
+            });
+
+            // copy new/modified templates to a temporary folder
+            if (!updatedTemplates.isEmpty()) {
+                getProject().copy(new Action<CopySpec>() {
+                    @Override
+                    public void execute(CopySpec spec) {
+                        spec.from(config.getTemplateDir());
+                        for (File file : updatedTemplates) {
+                            spec.include(relativePath(config.getTemplateDir(), file));
+                        }
+                        spec.into(tempDir);
+                    }
+                });
+            }
+
+            execResult = executeRocker(tempDir);
         } else {
             // delete any generated files from previous runs and any classes compiled by Rocker via hot-reloading
             getProject().delete(config.getOutputDir());
             getProject().delete(config.getClassDir());
+
+            // generate the files from the templates
+            execResult = executeRocker();
         }
-
-
-        // generate the files from the templates
-        ExecResult execResult = executeRocker();
 
         // for the Gradle Build Cache to function properly, the same inputs must always create exactly the same output
         // thus, if hot-reloading is disabled and the generated source code contains timestamps, we remove the MODIFIED_AT line
         RockerVersion rockerVersion = RockerVersion.fromProject(getProject());
         if (config.isOptimize() && rockerVersion.generatesRedundantCode_MODIFIED_AT()) {
-            trimLine_MODIFIED_AT();
+            trimLine_MODIFIED_AT(updatedTemplates);
         }
 
         // invoke custom result handler
@@ -112,6 +156,10 @@ public class RockerCompile extends DefaultTask {
     }
 
     private ExecResult executeRocker() {
+        return executeRocker(config.getTemplateDir());
+    }
+
+    private ExecResult executeRocker(final File templateDir) {
         return getProject().javaexec(new Action<JavaExecSpec>() {
 
             @Override
@@ -123,7 +171,7 @@ public class RockerCompile extends DefaultTask {
                 systemPropertyIfNotNull("rocker.option.extendsModelClass", config.getExtendsModelClass(), spec);
                 systemPropertyIfNotNull("rocker.option.javaVersion", config.getJavaVersion(), spec);
                 systemPropertyIfNotNull("rocker.option.targetCharset", config.getTargetCharset(), spec);
-                spec.systemProperty("rocker.template.dir", config.getTemplateDir().getAbsolutePath());
+                spec.systemProperty("rocker.template.dir", templateDir.getAbsolutePath());
                 spec.systemProperty("rocker.output.dir", config.getOutputDir().getAbsolutePath());
                 spec.systemProperty("rocker.class.dir", config.getClassDir().getAbsolutePath());
 
@@ -141,12 +189,18 @@ public class RockerCompile extends DefaultTask {
         });
     }
 
-    private void trimLine_MODIFIED_AT() throws IOException {
+    private void trimLine_MODIFIED_AT(final Collection<File> updated) throws IOException {
         Charset charset = Charset.forName(config.getTargetCharset());
         Set<File> generatedFiles = getProject().fileTree(config.getOutputDir(), new Action<ConfigurableFileTree>() {
             @Override
             public void execute(ConfigurableFileTree tree) {
-                tree.include("**/*.java");
+                if (updated.isEmpty()) {
+                    tree.include("**/*.java");
+                } else {
+                    for (File file : updated) {
+                        tree.include(relativePath(config.getOutputDir(), file));
+                    }
+                }
             }
         }).getFiles();
         for (File file : generatedFiles) {
@@ -157,4 +211,13 @@ public class RockerCompile extends DefaultTask {
         }
     }
 
+    private String relativePath(File baseDir, File child) {
+        return baseDir.toPath().relativize(child.toPath()).toString();
+    }
+
+    private String getSourceFileName(String templateName) {
+        int extension = templateName.indexOf(".rocker");
+        String baseName = templateName.substring(0, extension);
+        return baseName + ".java";
+    }
 }

--- a/src/main/java/nu/studer/gradle/rocker/RockerCompile.java
+++ b/src/main/java/nu/studer/gradle/rocker/RockerCompile.java
@@ -91,7 +91,7 @@ public class RockerCompile extends DefaultTask {
     @SuppressWarnings("unused")
     @TaskAction
     void doCompile(IncrementalTaskInputs incrementalTaskInputs) throws IOException {
-        ExecResult execResult;
+        ExecResult execResult = null;
         final Set<File> updatedTemplates = new HashSet<>();
 
         if (incrementalTaskInputs.isIncremental()) {
@@ -130,9 +130,9 @@ public class RockerCompile extends DefaultTask {
                         spec.into(tempDir);
                     }
                 });
-            }
 
-            execResult = executeRocker(tempDir);
+                execResult = executeRocker(tempDir);
+            }
         } else {
             // delete any generated files from previous runs and any classes compiled by Rocker via hot-reloading
             getProject().delete(config.getOutputDir());
@@ -150,7 +150,7 @@ public class RockerCompile extends DefaultTask {
         }
 
         // invoke custom result handler
-        if (execResultHandler != null) {
+        if (execResultHandler != null && execResult != null) {
             execResultHandler.execute(execResult);
         }
     }

--- a/src/main/java/nu/studer/gradle/rocker/RockerConfig.java
+++ b/src/main/java/nu/studer/gradle/rocker/RockerConfig.java
@@ -141,6 +141,12 @@ public class RockerConfig {
         this.classDir = classDir;
     }
 
+    @Internal
+    String getCompileTaskName() {
+        String finalName = name.equals("main") ? "" : StringUtils.capitalize(name);
+        return "compile" + finalName + "Rocker";
+    }
+
     @Override
     public String toString() {
         return "RockerConfig{" +

--- a/src/main/java/nu/studer/gradle/rocker/RockerPlugin.java
+++ b/src/main/java/nu/studer/gradle/rocker/RockerPlugin.java
@@ -17,6 +17,8 @@ import org.gradle.api.tasks.SourceSetContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static nu.studer.gradle.rocker.StringUtils.capitalize;
+
 @SuppressWarnings("unused")
 public class RockerPlugin implements Plugin<Project> {
 
@@ -50,8 +52,7 @@ public class RockerPlugin implements Plugin<Project> {
             @Override
             public void execute(RockerConfig config) {
                 // create rocker task
-                String taskName = taskName(config);
-                RockerCompile rocker = project.getTasks().create(taskName, RockerCompile.class);
+                RockerCompile rocker = project.getTasks().create(config.getCompileTaskName(), RockerCompile.class);
                 rocker.setGroup("Rocker");
                 rocker.setDescription("Invokes the Rocker template engine.");
                 rocker.setConfig(config);
@@ -102,16 +103,6 @@ public class RockerPlugin implements Plugin<Project> {
         project.getDependencies().add(rockerCompilerRuntime.getName(), "com.fizzed:rocker-compiler");
         project.getDependencies().add(rockerCompilerRuntime.getName(), "org.slf4j:slf4j-simple:1.7.23");
         return rockerCompilerRuntime;
-    }
-
-    private String taskName(RockerConfig config) {
-        String name = config.name;
-        String finalName = name.equals("main") ? "" : capitalize(name);
-        return "compile" + finalName + "Rocker";
-    }
-
-    private static String capitalize(String s) {
-        return s == null || s.isEmpty() ? s : Character.toUpperCase(s.charAt(0)) + s.substring(1);
     }
 
 }

--- a/src/main/java/nu/studer/gradle/rocker/RockerPlugin.java
+++ b/src/main/java/nu/studer/gradle/rocker/RockerPlugin.java
@@ -79,18 +79,13 @@ public class RockerPlugin implements Plugin<Project> {
         project.getConfigurations().all(new Action<Configuration>() {
             @Override
             public void execute(Configuration configuration) {
-                configuration.resolutionStrategy(new Action<ResolutionStrategy>() {
+                configuration.getResolutionStrategy().eachDependency(new Action<DependencyResolveDetails>() {
                     @Override
-                    public void execute(ResolutionStrategy resolutionStrategy) {
-                        resolutionStrategy.eachDependency(new Action<DependencyResolveDetails>() {
-                            @Override
-                            public void execute(DependencyResolveDetails details) {
-                                ModuleVersionSelector requested = details.getRequested();
-                                if (requested.getGroup().equals("com.fizzed") && requested.getName().startsWith("rocker-")) {
-                                    details.useVersion(RockerVersion.fromProject(project).asString());
-                                }
-                            }
-                        });
+                    public void execute(DependencyResolveDetails details) {
+                        ModuleVersionSelector requested = details.getRequested();
+                        if (requested.getGroup().equals("com.fizzed") && requested.getName().startsWith("rocker-")) {
+                            details.useVersion(RockerVersion.fromProject(project).asString());
+                        }
                     }
                 });
             }

--- a/src/main/java/nu/studer/gradle/rocker/RockerVersion.java
+++ b/src/main/java/nu/studer/gradle/rocker/RockerVersion.java
@@ -5,7 +5,7 @@ import org.gradle.api.Project;
 final class RockerVersion {
 
     private static final String PROJECT_PROPERTY = "rockerVersion";
-    private static final String DEFAULT = "0.16.0";
+    static final String DEFAULT = "0.16.0";
 
     private final String major;
     private final String minor;

--- a/src/main/java/nu/studer/gradle/rocker/StringUtils.java
+++ b/src/main/java/nu/studer/gradle/rocker/StringUtils.java
@@ -1,0 +1,7 @@
+package nu.studer.gradle.rocker;
+
+public abstract class StringUtils {
+    public static String capitalize(String s) {
+        return s == null || s.isEmpty() ? s : Character.toUpperCase(s.charAt(0)) + s.substring(1);
+    }
+}

--- a/src/test/groovy/nu/studer/gradle/rocker/BaseFuncTest.groovy
+++ b/src/test/groovy/nu/studer/gradle/rocker/BaseFuncTest.groovy
@@ -47,6 +47,7 @@ abstract class BaseFuncTest extends Specification {
             .withArguments(args)
             .withGradleVersion(gradleVersion.version)
             .withDebug(isDebuggerAttached())
+            .forwardOutput()
             .build()
     }
 

--- a/src/test/groovy/nu/studer/gradle/rocker/RockerFuncTest.groovy
+++ b/src/test/groovy/nu/studer/gradle/rocker/RockerFuncTest.groovy
@@ -3,6 +3,9 @@ package nu.studer.gradle.rocker
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Unroll
 
+import java.nio.file.Files
+import java.nio.file.attribute.BasicFileAttributes
+
 @Unroll
 class RockerFuncTest extends BaseFuncTest {
 
@@ -578,7 +581,70 @@ compileFooRocker {
         result.task(':compileFooRocker').outcome == TaskOutcome.SUCCESS
     }
 
-    private Writer rockerMainBuildFile(boolean optimize, String templateDir, String outputDir) {
+    def "only changed templates are regenerated when optimize=#optimize with rocker #rockerVersion"() {
+        given:
+        exampleTemplate()
+        def updatedTemplate = template('src/rocker/Updated.rocker.html')
+
+        and:
+        rockerMainBuildFile(optimize, 'src/rocker', 'src/generated/rocker', rockerVersion)
+
+        when:
+        def result = runWithArguments('compileRocker')
+
+        then:
+        def exampleLastModified = lastModified('src/generated/rocker/Example.java')
+        def updatedLastModified = lastModified('src/generated/rocker/Updated.java')
+        result.output.contains('Generated 2 rocker java source files')
+
+        when:
+        updatedTemplate << "Some more content"
+
+        and:
+        sleep(1000) // lazy workaround for the fact that Java's last modified time accuracy is pretty poor
+        result = runWithArguments('compileRocker')
+
+        then:
+        exampleLastModified == lastModified('src/generated/rocker/Example.java')
+        updatedLastModified < lastModified('src/generated/rocker/Updated.java')
+        result.output.contains('Generated 1 rocker java source files')
+
+        where:
+        [optimize, rockerVersion] << [[true, false], [RockerVersion.DEFAULT, '0.18.0']].combinations()
+    }
+
+    def "removed templates are cleaned up when optimize=#optimize with rocker #rockerVersion"() {
+        given:
+        exampleTemplate()
+        def deletedTemplate = template('src/rocker/Deleted.rocker.html')
+
+        and:
+        rockerMainBuildFile(optimize, 'src/rocker', 'src/generated/rocker', rockerVersion)
+
+        when:
+        def result = runWithArguments('compileRocker')
+
+        then:
+        fileExists('src/generated/rocker/Example.java')
+        fileExists('src/generated/rocker/Deleted.java')
+        result.output.contains('Generated 2 rocker java source files')
+
+        when:
+        deletedTemplate.delete()
+
+        and:
+        result = runWithArguments('compileRocker')
+
+        then:
+        fileExists('src/generated/rocker/Example.java')
+        !fileExists('src/generated/rocker/Deleted.java')
+        result.output.contains('Generated 0 rocker java source files')
+
+        where:
+        [optimize, rockerVersion] << [[true, false], [RockerVersion.DEFAULT, '0.18.0']].combinations()
+    }
+
+    private Writer rockerMainBuildFile(boolean optimize, String templateDir, String outputDir, String rockerVersion = RockerVersion.DEFAULT) {
         buildFile.newWriter().withWriter { w ->
             w << """
 plugins {
@@ -589,6 +655,8 @@ plugins {
 repositories {
     jcenter()
 }
+
+rockerVersion = '${rockerVersion}'
 
 rocker {
   main {
@@ -605,12 +673,12 @@ rocker {
         template('src/rocker/Example.rocker.html')
     }
 
-    private void template(String fileName) {
-        template(fileName, '')
+    private File template(String fileName) {
+        return template(fileName, '')
     }
 
-    private void template(String fileName, String customText) {
-        file(fileName) << """
+    private File template(String fileName, String customText) {
+        return file(fileName) << """
 @args (String message)
 Hello @message!$customText
 """
@@ -633,4 +701,8 @@ Hello @message!$customText
         file.setLastModified(System.currentTimeMillis() + 1000)
     }
 
+    private long lastModified(String filePath) {
+        def file = new File(workspaceDir, filePath)
+        return Files.readAttributes(file.toPath(), BasicFileAttributes).lastModifiedTime().toMillis()
+    }
 }

--- a/src/test/groovy/nu/studer/gradle/rocker/RockerFuncTest.groovy
+++ b/src/test/groovy/nu/studer/gradle/rocker/RockerFuncTest.groovy
@@ -638,7 +638,7 @@ compileFooRocker {
         then:
         fileExists('src/generated/rocker/Example.java')
         !fileExists('src/generated/rocker/Deleted.java')
-        result.output.contains('Generated 0 rocker java source files')
+        !(result.output =~ /Generated \d+ rocker java source files/)
 
         where:
         [optimize, rockerVersion] << [[true, false], [RockerVersion.DEFAULT, '0.18.0']].combinations()


### PR DESCRIPTION
This pull request makes the `RockerCompile` task incremental, meaning that only new/updated templates are passed to the Rocker compiler vs recompiling all existing templates on any change.