### PR TITLE
Ensure temporary directly is cleaned out between task executions

### DIFF
--- a/src/main/java/nu/studer/gradle/rocker/RockerCompile.java
+++ b/src/main/java/nu/studer/gradle/rocker/RockerCompile.java
@@ -146,6 +146,7 @@ public class RockerCompile extends DefaultTask {
             if (!modifiedTemplates.isEmpty()) {
                 // copy modified files to a temp directory since we can only point Rocker to a directory
                 final File tempDir = getTemporaryDir();
+                getProject().delete(tempDir);
 
                 getProject().copy(new Action<CopySpec>() {
                     @Override


### PR DESCRIPTION
This fix ensures that we don't accidentally keep around old state between build invocations be reusing stale incremental sources. This actually fixes two problems:

1. A file included in one incremental build (new or modified file) which is subsequently removed or renamed will be recompiled and placed in the output directory by mistake. Coupled with the build cache this can cause all sorts of problems.
2. As you run builds the task becomes less and less incremental, as the temporary directory "accumulates" files that have been changed over time meaning we actually are losing incrementalness.