### PR TITLE
Use implementation configuration for adding rocker runtime

### DIFF
--- a/src/main/java/nu/studer/gradle/rocker/RockerPlugin.java
+++ b/src/main/java/nu/studer/gradle/rocker/RockerPlugin.java
@@ -9,6 +9,7 @@ import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.util.GradleVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,9 +51,21 @@ public class RockerPlugin implements Plugin<Project> {
             SourceSet sourceSet = sourceSets.findByName(config.name);
             if (sourceSet != null) {
                 project.getTasks().getByName(sourceSet.getCompileJavaTaskName()).dependsOn(rocker);
-                project.getDependencies().add(sourceSet.getCompileConfigurationName(), "com.fizzed:rocker-runtime");
+                project.getDependencies().add(getCompileConfigurationName(sourceSet), "com.fizzed:rocker-runtime");
             }
         });
+    }
+
+    /**
+     * For older gradle versions we fall back to `compile`.
+     * Newer gradle versions will use `implementation` instead of the deprecated `compile` configuration.
+     * */
+    private String getCompileConfigurationName(SourceSet sourceSet) {
+        return isAtLeastGradle5() ? sourceSet.getImplementationConfigurationName() : sourceSet.getCompileConfigurationName();
+    }
+
+    private boolean isAtLeastGradle5() {
+        return GradleVersion.current().compareTo(GradleVersion.version("5.0")) >= 0;
     }
 
     private void enforceRockerVersion(final Project project) {

--- a/src/test/groovy/nu/studer/gradle/rocker/BaseFuncTest.groovy
+++ b/src/test/groovy/nu/studer/gradle/rocker/BaseFuncTest.groovy
@@ -37,10 +37,13 @@ abstract class BaseFuncTest extends Specification {
     void setup() {
         workspaceDir = new File(tempDir.root, testName.methodName)
         gradleVersion = determineGradleVersion()
+        settingsFile << """
+            rootProject.name = 'test-project'
+        """
     }
 
     protected BuildResult runWithArguments(String... args) {
-        GradleRunner.create()
+        assertNoDeprecatedBuildResult(GradleRunner.create()
             .withPluginClasspath()
             .withTestKitDir(testKitDir)
             .withProjectDir(workspaceDir)
@@ -48,7 +51,12 @@ abstract class BaseFuncTest extends Specification {
             .withGradleVersion(gradleVersion.version)
             .withDebug(isDebuggerAttached())
             .forwardOutput()
-            .build()
+            .build())
+    }
+
+    BuildResult assertNoDeprecatedBuildResult(BuildResult buildResult) {
+        assert !buildResult.output.contains("Deprecated Gradle features were used in this build")
+        buildResult
     }
 
     protected File getBuildFile() {


### PR DESCRIPTION
the compile configururation was deprecated in gradle. This replaces its usage in the rocker plugin if gradle >= 5 is used.

- Also added basic test coverage for no used deprecated gradle api