### PR TITLE
Remove empty directories from the generated outupt directory

### DIFF
--- a/src/main/java/nu/studer/gradle/rocker/RockerCompile.java
+++ b/src/main/java/nu/studer/gradle/rocker/RockerCompile.java
@@ -30,6 +30,8 @@ import org.gradle.work.InputChanges;
 
 import javax.inject.Inject;
 import java.io.File;
+import java.io.FileFilter;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -210,6 +212,7 @@ public class RockerCompile extends DefaultTask {
             // remove the compiled files for any removed templates
             if (!removedTemplates.isEmpty()) {
                 fileSystemOperations.delete(spec -> spec.delete(removedTemplates));
+                deleteEmptyDirRecursively(outputDir.get().getAsFile());
             }
         }
 
@@ -258,6 +261,16 @@ public class RockerCompile extends DefaultTask {
     private static String toJavaClassFileName(String templateName) {
         int extension = templateName.indexOf(ROCKER_FILE_EXTENSION_PREFIX);
         return extension > -1 ? templateName.substring(0, extension) + ".class" : null;
+    }
+
+    private void deleteEmptyDirRecursively(File aDir) {
+        if (!aDir.exists() || !aDir.isDirectory()) {
+            return;
+        }
+        Arrays.stream(aDir.listFiles(File::isDirectory)).forEach(this::deleteEmptyDirRecursively);
+        if (aDir.list().length == 0) {
+            fileSystemOperations.delete(spec -> spec.delete(aDir));
+        }
     }
 
 }


### PR DESCRIPTION
In case of incremental compilation, the removed templates are correctly triggering a deletion of the corresponding compiled templates.
Yet, empty directories could remain in the generated output directory.
If these directories are used as inputs to a subsequent Gradle task, they will cause a different cache key computation (compared to a case where the same rocker templates are declared, but without these empty directories in the generated directory), causing a cache miss for this subsequent task.

Fixes #9 

Build scan link with all passing tests: https://scans.gradle.com/s/56qj5hx7er6cu