### PR TITLE
Bump com.gradle.plugin-publish from 0.21.0 to 1.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ import static java.lang.Integer.parseInt
 
 plugins {
     id 'nu.studer.plugindev' version '4.1'
-    id 'com.gradle.plugin-publish' version '0.21.0'
+    id 'com.gradle.plugin-publish' version '1.0.0'
     id 'org.nosphere.gradle.github.actions' version '1.3.2'
     id 'groovy'
 }
@@ -54,6 +54,8 @@ gradlePlugin {
     plugins {
         pluginDevPlugin {
             id = 'nu.studer.rocker'
+            displayName = 'gradle-rocker-plugin'
+            description = 'Gradle plugin that integrates the Rocker template engine.'
             implementationClass = 'nu.studer.gradle.rocker.RockerPlugin'
         }
     }
@@ -62,17 +64,5 @@ gradlePlugin {
 pluginBundle {
     website = 'https://github.com/etiennestuder/gradle-rocker-plugin'
     vcsUrl = 'https://github.com/etiennestuder/gradle-rocker-plugin'
-    description = 'Gradle plugin that integrates the Rocker template engine.'
     tags = ['rocker']
-
-    plugins {
-        pluginDevPlugin {
-            displayName = 'gradle-rocker-plugin'
-        }
-    }
-
-    mavenCoordinates {
-        groupId = 'nu.studer'
-        artifactId = 'gradle-rocker-plugin'
-    }
 }


### PR DESCRIPTION
Dependabot was unable to perform an automated update of `com.gradle.plugin-publish` from 0.21.0 to 1.0.0.

This PR updates the plugin and migrates to the new API.