### PR TITLE
Bump Gradle Wrapper from 8.0 to 8.0.1 in /example/remote_template

### DIFF
--- a/example/remote_template/gradle/wrapper/gradle-wrapper.properties
+++ b/example/remote_template/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=4159b938ec734a8388ce03f52aa8f3c7ed0d31f5438622545de4f83a89b79788
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionSha256Sum=1b6b558be93f29438d3df94b7dfee02e794b94d9aca4611a92cdb79b6b88e909
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Bumps Gradle Wrapper from 8.0 to 8.0.1.

Release notes of Gradle 8.0.1 can be found here:
https://docs.gradle.org/8.0.1/release-notes.html