### PR TITLE
Bump Gradle Wrapper from 8.12 to 8.12.1 in /example/kotlin

### DIFF
--- a/example/kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/example/kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=7a00d51fb93147819aab76024feece20b6b84e420694101f276be952e08bef03
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionSha256Sum=8d97a97984f6cbd2b85fe4c60a743440a347544bf18818048e611f5288d46c94
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Bump Gradle Wrapper from 8.12 to 8.12.1.

Release notes of Gradle 8.12.1 can be found here:
https://docs.gradle.org/8.12.1/release-notes.html