### PR TITLE
Bump Gradle Wrapper from 8.14 to 8.14.1 in /example/remote_template

### DIFF
--- a/example/remote_template/gradle/wrapper/gradle-wrapper.properties
+++ b/example/remote_template/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=61ad310d3c7d3e5da131b76bbf22b5a4c0786e9d892dae8c1658d4b484de3caa
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionSha256Sum=845952a9d6afa783db70bb3b0effaae45ae5542ca2bb7929619e8af49cb634cf
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Bump Gradle Wrapper from 8.14 to 8.14.1.

Release notes of Gradle 8.14.1 can be found here:
https://docs.gradle.org/8.14.1/release-notes.html