### PR TITLE
Bump Gradle Wrapper from 8.14 to 8.14.2 in /example/groovy

### DIFF
--- a/example/groovy/gradle/wrapper/gradle-wrapper.properties
+++ b/example/groovy/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=61ad310d3c7d3e5da131b76bbf22b5a4c0786e9d892dae8c1658d4b484de3caa
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionSha256Sum=7197a12f450794931532469d4ff21a59ea2c1cd59a3ec3f89c035c3c420a6999
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Bump Gradle Wrapper from 8.14 to 8.14.2.

Release notes of Gradle 8.14.2 can be found here:
https://docs.gradle.org/8.14.2/release-notes.html