### PR TITLE
Onboard to the OSS Community Develocity Instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <p align="left">
   <a href="https://github.com/etiennestuder/gradle-rocker-plugin/actions?query=workflow%3A%22Build+Gradle+project%22"><img src="https://github.com/etiennestuder/gradle-rocker-plugin/workflows/Build%20Gradle%20project/badge.svg"></a>
+  <a href="https://community.develocity.cloud/scans?search.rootProjectNames=gradle-rocker-plugin"><img src="https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A" alt="Revved up by Develocity"></a>
 </p>
 
 gradle-rocker-plugin

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.gradle.develocity' version '4.4.0'
+    id 'com.gradle.develocity' version '4.4.1'
     id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.6.0'
     id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
 }
@@ -7,7 +7,8 @@ plugins {
 def isCI = System.getenv('CI') != null
 
 develocity {
-    server = 'https://etiennestuder.develocity.cloud'
+    server = 'https://community.develocity.cloud'
+    projectId = 'etiennestuder'
 
     buildScan {
         publishing.onlyIf { it.authenticated }


### PR DESCRIPTION
# Onboard to the OSS Community Develocity Instance

This PR adds [Develocity](https://gradle.com/develocity) Build Scan® and Build Cache support
for this project, publishing to the **OSS Community Develocity Instance** at
<https://community.develocity.cloud> under project ID `etiennestuder`.

## What this PR adds

- Updated the Develocity Gradle plugin to version 4.4.1 and the Common Custom User Data
  Gradle plugin to version 2.6.0, migrating the server from `etiennestuder.develocity.cloud`
  to `community.develocity.cloud`.
- `settings.gradle` pointing the build at `https://community.develocity.cloud` and
  associating builds with project `etiennestuder`.
- A "Revved up by Develocity" badge in the README linking to the filtered Build Scan list
  for this project's root project name.

## Required next step — set a GitHub Actions secret

Build Scan publishing **and** Build Cache writes from CI **will not work** until you create a
repository secret named `DV_ACCESS_KEY` on **this repository** (or update its existing value).
The value must include the **host name** of the Develocity instance, in the form `<host>=<access-key>`:

```
DV_ACCESS_KEY = community.develocity.cloud=<your-access-key>
```

The hostname prefix is required — without it, the access key is silently ignored. This is
the most common point of failure when onboarding, so please double-check the format.

To get an access key: visit <https://community.develocity.cloud>, sign in, and use
"My settings" → "Access keys".

## Why the CI run on this PR doesn't prove the connection works

This PR was prepared from a fork. Forks can't read your repository's secrets, so the
workflow run on this PR cannot publish to `community.develocity.cloud` even after you set
the secret on the upstream repository.

If you want CI verification before merging, push the branch
`dv/onboard-oss-community-develocity-instance` to a temporary branch on **this** repo (not
the fork) and re-run the workflow there — it will pick up the secret and publish a Build
Scan.

After merging, every CI run **on this repository** will publish a Build Scan to
<https://community.develocity.cloud>. CI runs from forks of this repository will not (forks
don't have access to the secret either), and that's expected.

## Required next step - provision local access keys

Build Scan publishing from local builds **will not work** until you provision access keys. Authenticated users can create an access key automatically by invoking:

```
./gradlew provisionDevelocityAccessKey
```