### PR TITLE
Bring back testing with JDK 8

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -10,11 +10,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [ "11", "17", "21", "25" ]
+        java-version: [ "8", "11", "17", "21", "25" ]
         gradle-version: [ "6.9.4", "7.0.2", "7.6.6", "8.0.2", "8.14.5", "9.0.0", "9.5.1" ]
     steps:
       - name: Check out project
         uses: actions/checkout@v6
+      - name: Set up JDK 8
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'liberica'
+          java-version: 8
       - name: Set up JDK 11
         uses: actions/setup-java@v5
         with:


### PR DESCRIPTION
## Summary
- Re-adds Java 8 to the CI test matrix
- Adds the corresponding `Set up JDK 8` step in the workflow

This was dropped unintentionally when the matrix was last updated. The `sourceCompatibility`/`targetCompatibility = VERSION_1_8` settings already ensure the compiled bytecode is compatible with Java 8.

## Test plan
- [ ] CI matrix runs green across all Java/Gradle combinations including Java 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)